### PR TITLE
update calling nonzero method

### DIFF
--- a/torch_sampler.py
+++ b/torch_sampler.py
@@ -87,7 +87,7 @@ class BySequenceLengthSampler(Sampler):
     def element_to_bucket_id(self, x, seq_length):
 
         valid_buckets = (seq_length >= self.buckets_min)*(seq_length < self.buckets_max)
-        bucket_id = valid_buckets.nonzero()[0].item()
+        bucket_id = torch.nonzero(valid_buckets, as_tuple=True)[0].item()
 
         return bucket_id
     


### PR DESCRIPTION
- Fixes the following warning about the nonzero method:
```bash
......... : UserWarning: This overload of nonzero is deprecated:
        nonzero()
Consider using one of the following signatures instead:
        nonzero(*, bool as_tuple) (Triggered internally at  /pytorch/torch/csrc/utils/python_arg_parser.cpp:882.)
  bucket_id = valid_buckets.nonzero()[0].item()

```